### PR TITLE
License draft proposal from @mwweinberg

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,45 @@
+# ml5.js LICENSE
+
+_This is a discussion draft of a possible license for ml5.js. It does not currently apply to the ml5.js library. The license is based on the [Blue Oak Council Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0), although in no way endorsed or supported by the Blue Oak Council._
+
+## Purpose
+
+This license gives everyone as much permission to work with this software as possible as long as they comply with the ml5.js [Code of Conduct](README.md), while protecting contributors from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its rules. The rules of this license are both obligations under that agreement and conditions to your license. You must not do anything with this software that triggers a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor’s copyright in it.
+
+## License Reversion
+
+Each contribution to this software is licensed under this license for three years from the date it is contributed to the software. After that three year period the contribution is licensed under the MIT license.
+
+## Code of Conduct
+
+You must use this software in compliance with the ml5.js [Code of Conduct](README.md) as it exists at the time of your use. This includes cooperating with any investigations of your compliance with the ml5.js Code of Conduct.
+
+## Notices
+
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to [canonical URL for the license].
+
+## Excuse
+
+If anyone notifies you in writing that you have not complied with Notices, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
+
+If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**


### PR DESCRIPTION
This is a discussion draft of a possible license for ml5.js. It does not currently apply to the ml5.js library.  The license is based on the [Blue Oak Council Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0), although in no way endorsed or supported by the Blue Oak Council.

@mwweinberg is it useful to now (or at some point in the future) *name* this license? Is this the "ml5" license?

Also, this particular section is confusing to me:

> Each contributor licenses you to do everything with this software that would otherwise infringe that contributor’s copyright in it.

Along with:

> Each contribution to this software is licensed under this license for three years from the date it is contributed to the software. After that three year period the contribution is licensed under the MIT license.

I think the distinction between a contribution to ml5.js from one of us or another community member vs. a use of ml5.js under the license will be hard for people to parse. Perhaps an FAQ can help address this in the future.