### PR TITLE
tighten compliance requirement for CoC

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,7 +30,7 @@ You must ensure that everyone who gets a copy of any part of this software from 
 
 If anyone notifies you in writing that you have not complied with Notices, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
 
-If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
+If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by complying within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
 
 ## Patent
 


### PR DESCRIPTION
The CoC has components that apply to corporate users, and in particular in ways that may clash with entire business models ("Do not ... Use ml5.js to build tools of mass surveillance"). "all practical steps", while perhaps appropriate for a notice requirement, is perhaps an out clause for use that would otherwise require a change in business model (impractical for most businesses!) 

This PR tightens the language, in light of that concern.

Note that accepting this PR may make the conversation proposed in issue #2 (already unlikely to be easy) more complex.