### PR TITLE
License Updates in Preparation of Launch

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,7 +24,7 @@ You must use this software in compliance with the ml5.js [Code of Conduct](READM
 
 ## Notices
 
-You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md.
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://ml5js.org/license.
 
 ## Excuse
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -28,7 +28,7 @@ You must ensure that everyone who gets a copy of any part of this software from 
 
 ## Excuse
 
-If anyone notifies you in writing that you have not complied with [Notices](https://blueoakcouncil.org/license/1.0.0#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
+If anyone notifies you in writing that you have not complied with [Notices](https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
 
 If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -16,19 +16,19 @@ Each contributor licenses you to do everything with this software that would oth
 
 ## License Reversion
 
-Each contribution to this software is licensed under this license for three years from the date it is contributed to the software. After that three year period the contribution is licensed under the MIT license.
+Each contribution to this software is licensed under this license for three years from the date it is contributed to the software. After that three year period the contribution is licensed under the [Blue Oak Model License v 1.0.0](https://blueoakcouncil.org/license/1.0.0).
 
 ## Code of Conduct
 
-You must use this software in compliance with the ml5.js [Code of Conduct](README.md) as it exists at the time of your use. This includes cooperating with any investigations of your compliance with the ml5.js Code of Conduct by the Code of Conduct Comittee or any contributor or their designees.
+You must use this software in compliance with the ml5.js [Code of Conduct](README.md) as it exists at the time of your use. This includes cooperating with any investigations of your compliance with the ml5.js Code of Conduct.
 
 ## Notices
 
-You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to [canonical URL for the license].
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license or a link to https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md.
 
 ## Excuse
 
-If anyone notifies you in writing that you have not complied with Notices, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
+If anyone notifies you in writing that you have not complied with [Notices](https://blueoakcouncil.org/license/1.0.0#notices), you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your license ends immediately.
 
 If anyone notifies you in writing that you have not complied with the Code of Conduct, you can keep your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, and the ml5.js Code of Conduct Committee (or its equivalent or successor) agrees that you are in violation of the Code of Conduct, your license ends immediately.
 
@@ -43,3 +43,7 @@ No contributor can revoke this license.
 ## No Liability
 
 **_As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**
+
+## Permission
+
+Each contributor licenses you to do everything with this license that would otherwise infringe that contributor’s copyright in it.


### PR DESCRIPTION
This pull request includes some minor updates and changes to the license text. Two questions:

- @bomanimc What do you think about creating an alias from `http://ml5js.org/license` to `LICENSE.md`? Then this can be the canonical license url giving us the freedom to restructure/reorganize the way this GitHub repo is organized / published.
- @mwweinberg When should the opening text about this being not the active / actual license be removed?

Where else in the various ml5 source code or community spaces do we need to update license information?