### PR TITLE
Updating FAQ / funding disclosure

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -68,3 +68,7 @@ The ml5.js library, though now broadly applicable in native JavaScript, was orig
 ### COSA
 
 The ml5.js project has received support from the [Clinic for Open-Source Arts](https://www.du.edu/ahss/opensourcearts/).
+
+### Frank-Ratchye STUDIO for Creative Inquiry
+
+The ml5.js project has received support from the [Frank-Ratchye STUDIO for Creative Inquiry](https://studioforcreativeinquiry.org/)

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,16 +36,7 @@ Second, it makes revising or changing the license easier. The ml5.js license is 
 
 The Code of Conduct Committee is responsible for maintaining the Code of Conduct as well as deciding if a given use of ml5.js violates the Code of Conduct. It can make those decisions in response to a specific request, or through an investigation it initiates directly.
 
-The Code of Conduct Committee’s members are:
-
-- Christina Dacanay
-- Lydia Jessup
-- Sam Krystal
-- Joey Lee
-- Ashley Jane Lewis
-- Bomani Oseni McClendon
-- Daniel Shiffman
-- Michael Weinberg
+The Code of Conduct Committee is [currently made up of ml5.js community members responsible for originally drafting the Code of Conduct](https://github.com/ml5js/Code-of-Conduct/blob/main/README.md#ml5js-code-of-conduct-steering-committee). It is responsible developing governance structures for the Code of Conduct Committee itself going forward.
 
 If you believe that a project that incorporates ml5.js violates the Code of Conduct, or are concerned that your own project may violate the Code of Conduct, we ask that you report it by emailing info@ml5js.org. Please include your name and a description of the incident.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,37 +1,70 @@
 # Frequently Asked Questions
 
-This evolving FAQ covers questions related to to the ml5.js [license](https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md) and [Code of Conduct](https://github.com/ml5js/Code-of-Conduct).  Please open an [issue](https://github.com/ml5js/Code-of-Conduct/issues) if you have a question that is not covered by this document.
+This evolving FAQ covers questions related to to the ml5.js [license](https://github.com/ml5js/Code-of-Conduct/blob/main/LICENSE.md), [Code of Conduct](https://github.com/ml5js/Code-of-Conduct), and funding/governance or the ml5.js project. Please open an [issue](https://github.com/ml5js/Code-of-Conduct/issues) if you have a question that is not covered by this document.
 
 ## How are the ml5.js license and Code of Conduct related?
 
-The ml5.js license is a legal agreement that allows users to make use of the ml5.js library. The Code of Conduct has rules you agree to follow when you accept that license.   
+The ml5.js license is a legal agreement that allows users to make use of the ml5.js library. The Code of Conduct has rules you agree to follow when you accept that license.
 
-The ml5.js license allows users to use the ml5.js library as long as they follow a small number of rules (called “terms”).  One of the terms is that you agree to follow the ml5.js Code of Conduct.  The license makes it a legal obligation to follow the rules set out in the Code of Conduct.  
+The ml5.js license allows users to use the ml5.js library as long as they follow a small number of rules (called “terms”). One of the terms is that you agree to follow the ml5.js Code of Conduct. The license makes it a legal obligation to follow the rules set out in the Code of Conduct.
 
 ## Who owns the copyright in ml5.js?
 
-The ml5.js library is made up of thousands of individual contributions from the ml5.js community.  These take the form of commits to the ml5.js repo.  Each contributor owns the copyright in their contribution and licenses the contribution to the rest of the ml5.js community using the same license that governs ml5.js as a whole.  
+The ml5.js library is made up of thousands of individual contributions from the ml5.js community. These take the form of commits to the ml5.js repo. Each contributor owns the copyright in their contribution and licenses the contribution to the rest of the ml5.js community using the same license that governs ml5.js as a whole.
 
 This means that there is no central ml5.js organization that owns the copyright to the ml5.js library.
 
 ## How are violations of the license enforced?
 
-Since there is no central ml5.js organization that owns the copyright to the ml5.js library, there is no central ml5.js organization to enforce the terms of the copyright license or the Code of Conduct.  Instead, any individual contributor to ml5.js can raise concerns about license violations.
+Since there is no central ml5.js organization that owns the copyright to the ml5.js library, there is no central ml5.js organization to enforce the terms of the copyright license or the Code of Conduct. Instead, any individual contributor to ml5.js can raise concerns about license violations.
 
-If a contributor believes that a user of ml5.js is violating the Code of Conduct, the contributor can refer the user to the Code of Conduct Committee.  If the Code of Conduct Committee agrees that the user is violating the Code of Conduct, and the user does not remedy the situation, the contributor may be able to bring a copyright infringement lawsuit against the user.
+If a contributor believes that a user of ml5.js is violating the Code of Conduct, the contributor can refer the user to the Code of Conduct Committee. If the Code of Conduct Committee agrees that the user is violating the Code of Conduct, and the user does not remedy the situation, the contributor may be able to bring a copyright infringement lawsuit against the user.
 
 ## What is ‘license decay’ and why does it matter?
 
-The ml5.js license requires users to comply with the ml5.js Code of Conduct for the first three years after the commit is made to the repo.  After three years, the ml5.js license “decays” into an MIT license.
+The ml5.js license requires users to comply with the ml5.js Code of Conduct for the first three years after the commit is made to the repo. After three years, the ml5.js license “decays” into an MIT license.
 
 As long as the ml5.js library is in active development, it is likely that there will always be parts of the library that are licensed under the ml5.js license. As a result, users of the ml5.js library will be required to comply with the Code of Conduct.
 
 However, if the ml5.js library ceases to be actively developed, eventually all of the commits will be more than three years old. At that point the entire library will be licensed under the MIT license.
 
-This achieves two goals. First, it makes sure that users are not tied to an inactive process.  The ml5.js license relies on an active Code of Conduct Committee to enforce the license.  If the library is no longer being actively developed, it is likely that the Code of Conduct Committee is also no longer active as well.  Instead of binding users to comply with a process that no longer exists, decaying to the MIT license allows users to comply with its much more straightforward terms.
+This achieves two goals. First, it makes sure that users are not tied to an inactive process. The ml5.js license relies on an active Code of Conduct Committee to enforce the license. If the library is no longer being actively developed, it is likely that the Code of Conduct Committee is also no longer active as well. Instead of binding users to comply with a process that no longer exists, decaying to the MIT license allows users to comply with its much more straightforward terms.
 
-Second, it makes revising or changing the license easier.  The ml5.js license is an experiment in ethical licensing.  If it turns out we made a horrible mistake, we only have to wait for three years until it disappears.  
+Second, it makes revising or changing the license easier. The ml5.js license is an experiment in ethical licensing. If it turns out we made a horrible mistake, we only have to wait for three years until it disappears.
 
 ## Who is on the Code of Conduct Committee and how is the Committee selected?
 
-The Code of Conduct Committee is responsible for maintaining the Code of Conduct and reviewing accused violations of the Code of Conduct.  The Committee selection process will be finalized as part of the community review of the proposed license.  Once finalized, the will be incorporated into the Code of Conduct and current members will be listed in the document. 
+The Code of Conduct Committee is responsible for maintaining the Code of Conduct as well as deciding if a given use of ml5.js violates the Code of Conduct. It can make those decisions in response to a specific request, or through an investigation it initiates directly.
+
+The Code of Conduct Committee’s members are:
+
+- Christina Dacanay
+- Lydia Jessup
+- Sam Krystal
+- Joey Lee
+- Ashley Jane Lewis
+- Bomani Oseni McClendon
+- Daniel Shiffman
+- Michael Weinberg
+
+If you believe that a project that incorporates ml5.js violates the Code of Conduct, or are concerned that your own project may violate the Code of Conduct, we ask that you report it by emailing info@ml5js.org. Please include your name and a description of the incident.
+
+## How is ml5.js funded?
+
+The development of the ml5.js project has been made possible through financial and “in kind” support from institutions.
+
+### ITP/IMA at NYU
+
+The project began as a series of short experiments by students and faculty at ITP/MA which combined elements of TensorFlow.js (then called ‘deeplearn.js’) and p5.js in examples for the coding curriculum. Since then development of the project has almost entirely happened through for-credit internships, student work-study, class assignments, staff administrative support, and informal volunteer clubs and workshops at ITP/IMA itself.
+
+### Google
+
+The ml5.js codebase itself is almost entirely built on top of TensorFlow.js, an open source machine learning library in JavaScript maintained by researchers and employees of Google (Alphabet, Inc.). TensorFlow.js, itself, is a subset of the larger TensorFlow machine learning ecosystem across many programming languages and frameworks, also maintained by Google. Funding from the form of two unrestricted cash gifts from Google University Relations has paid for the bulk of expenses associated with the support from ITP/IMA. This funding was made possible through our collaboration with the TensorFlow.js research and development team which is part of People + AI Research (PAIR) at Google.
+
+### Processing Foundation
+
+The ml5.js library, though now broadly applicable in native JavaScript, was originally intended as a “plug-in” to add machine learning capabilities to the general purpose creative coding library p5.js, maintained and developed by The Processing Foundation. The Processing Foundation has contributed to the development of ml5.js in a myriad of ways via the intersection of the ml5.js and creative coding communities. Processing Foundation fellowships and other community events have featured and provided support for ml5.js.
+
+### COSA
+
+The ml5.js project has received support from the [Clinic for Open-Source Arts](https://www.du.edu/ahss/opensourcearts/).


### PR DESCRIPTION
This pull request updates the FAQ to reflect the Steering Committee membership and other details in preparation for launch (#27) I've also chosen to add the context about project funding to this document rather than create a separate one. I wonder if something like this should make its way onto ml5js.org as well?